### PR TITLE
add simultaneously recognizing

### DIFF
--- a/Example/index.ios.js
+++ b/Example/index.ios.js
@@ -16,6 +16,8 @@ import reactNativeTvosController from "react-native-tvos-controller";
 
 reactNativeTvosController.connect();
 reactNativeTvosController.enablePanGesture();
+reactNativeTvosController.enableRecognizeSimultaneously();
+
 // reactNativeTvosController.disablePanGesture(); // uncomment to disable Pan Gesture
 var tapSubscription = reactNativeTvosController.subscribe('TAP',
     (e) => {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ reactNativeTvosController.enablePanGesture();
 You will receive the specific moving offset tracing data if you enable the pan gesture.
 You can't receive the swipe event anymore.
 
+You can receive the swipe event and other gestures when it was enabled simultaneously recognizing `reactNativeTvosController.enableRecognizeSimultaneously()`
+
 ### disablePanGesture
 
 ```javascript
@@ -70,6 +72,18 @@ reactNativeTvosController.disablePanGesture();
 ```
 You won't receive the specific moving offset tracing data if you disable the pan gesture.
 You can continue receiving the swipe event.
+
+### enableRecognizeSimultaneously
+
+```javascript
+reactNativeTvosController.enableRecognizeSimultaneously();
+```
+Events from all recognizers are sending simultaneously.
+
+```javascript
+reactNativeTvosController.enableRecognizeSimultaneously(false);
+```
+Disable. Events will be send from the first recognized gesture recognizer.
 
 ### subscribe
 
@@ -89,7 +103,7 @@ var tapSubscription = reactNativeTvosController.subscribe('TAP',
       e.code : 0 || 1 || 2 || 3 || 4 || 5 || 6
       */
     });
-    tapSubscription(); //Cancel Subscription 
+    tapSubscription(); //Cancel Subscription
 ```
 
 ##### SWIPE
@@ -101,10 +115,10 @@ var swipeSubscription = reactNativeTvosController.subscribe('SWIPE',
       console.log(JSON.stringify(e));
       /*
       e.direction : "Right" || "Down" || "Left" || "Up"
-      e.code : 0 || 1 || 2 || 3 
+      e.code : 0 || 1 || 2 || 3
       */
     });
-    swipeSubscription(); //Cancel Subscription 
+    swipeSubscription(); //Cancel Subscription
 ```
 
 ##### LONGPRESS

--- a/ReactNativeTvosController/ReactNativeTvosController/ReactNativeTvosController.h
+++ b/ReactNativeTvosController/ReactNativeTvosController/ReactNativeTvosController.h
@@ -12,6 +12,6 @@
 #import "RCTBridgeModule.h"
 #import "RCTEventEmitter.h"
 
-@interface ReactNativeTvosController : RCTEventEmitter <RCTBridgeModule>
+@interface ReactNativeTvosController : RCTEventEmitter <RCTBridgeModule, UIGestureRecognizerDelegate>
 
 @end

--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = {
     disablePanGesture: function(){
         NativeModules.ReactNativeTvosController.disablePanGesture();
     },
+    enableRecognizeSimultaneously: function(recognizeSimultaneously = true){
+        NativeModules.ReactNativeTvosController.enableRecognizeSimultaneously(recognizeSimultaneously);
+    },
     subscribe: function(event, callback){
         nativeEventEmitter.addListener(event, callback);
         return function(){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tvos-controller",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TvOS remote controller module for react native.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
reactNativeTvosController.enableRecognizeSimultaneously()
- all recognizers send events simultaneously
- so you can get e.g. pan events with long press event or select button pressed
etc. without needed to make new touch on the remote controller touchpad (release
finger from touchpad and make new tap)

reactNativeTvosController.enableRecognizeSimultaneously(false)
- disable this feature