### PR TITLE
Add TypeScript typings, breakup connect and add disconnect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,12 @@
 export const connect: () => void;
+export const connectTap: () => void;
+export const connectSwipe: () => void;
+export const connectLongPress: () => void;
+
+export const disconnect: () => void;
+export const disconnectTap: () => void;
+export const disconnectSwipe: () => void;
+export const disconnectLongPress: () => void;
 
 export const enablePanGesture: () => void;
 export const disablePanGesture: () => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,35 @@
+export const connect: () => void;
+
+export const enablePanGesture: () => void;
+export const disablePanGesture: () => void;
+export const enableRecognizeSimultaneously: () => void;
+export const disableRecognizeSimultaneously: () => void;
+
+export type CancelSubscription = () => void;
+export interface PanEvent {
+    state: "Began" | "Changed" | "Ended";
+    x: number;
+    velocityX: number;
+    y: number;
+    velocityY: number;
+}
+export interface TapEvent {
+    type:
+        | "PlayPause"
+        | "Menu"
+        | "Select"
+        | "UpArrow"
+        | "DownArrow"
+        | "LeftArrow"
+        | "RightArrow";
+    code: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+}
+export function subscribe(
+    eventType: "PAN",
+    handler: (event: PanEvent) => void
+): CancelSubscription;
+
+export function subscribe(
+    eventType: "TAP",
+    handler: (event: TapEvent) => void
+): CancelSubscription;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,27 @@ import {
       connect: function(){
           NativeModules.ReactNativeTvosController.connect();
       },
+      connectTap: function(){
+          NativeModules.ReactNativeTvosController.connectTap();
+      },
+      connectSwipe: function(){
+          NativeModules.ReactNativeTvosController.connectSwipe();
+      },
+      connectLongPress: function(){
+          NativeModules.ReactNativeTvosController.connectLongPress();
+      },
+      disconnect: function(){
+          NativeModules.ReactNativeTvosController.disconnect();
+      },
+      disconnectTap: function(){
+          NativeModules.ReactNativeTvosController.disconnectTap();
+      },
+      disconnectSwipe: function(){
+          NativeModules.ReactNativeTvosController.disconnectSwipe();
+      },
+      disconnectLongPress: function(){
+          NativeModules.ReactNativeTvosController.disconnectLongPress();
+      },
       enablePanGesture: function(){
           NativeModules.ReactNativeTvosController.enablePanGesture();
       },

--- a/ios/RNtvoscontroller/RNtvoscontroller.m
+++ b/ios/RNtvoscontroller/RNtvoscontroller.m
@@ -12,9 +12,19 @@
 
 UIPanGestureRecognizer *panGestureRecognizer;
 
+NSMutableArray *tapRecognizers;
+NSMutableArray *swipeRecognizers;
+NSMutableArray *longPressRecognizers;
+
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(connect) {
+    [self connectTap];
+    [self connectSwipe];
+    [self connectLongPress];
+}
+
+RCT_EXPORT_METHOD(connectTap) {
     self.recognizeSimultaneously = NO;
     UIView *rootView = [self getRootViewController].view;
     
@@ -25,13 +35,65 @@ RCT_EXPORT_METHOD(connect) {
     [self addTapGestureRecognizerWithType:rootView pressType:UIPressTypeDownArrow selector:@selector(respondToDownArrowButton)];
     [self addTapGestureRecognizerWithType:rootView pressType:UIPressTypeLeftArrow selector:@selector(respondToLeftArrowButton)];
     [self addTapGestureRecognizerWithType:rootView pressType:UIPressTypeRightArrow selector:@selector(respondToRightArrowButton)];
+}
+
+RCT_EXPORT_METHOD(connectSwipe) {
+    self.recognizeSimultaneously = NO;
+    UIView *rootView = [self getRootViewController].view;
     
     [self addSwipeGestureRecognizerWithDirection:rootView direction:UISwipeGestureRecognizerDirectionRight];
     [self addSwipeGestureRecognizerWithDirection:rootView direction:UISwipeGestureRecognizerDirectionLeft];
     [self addSwipeGestureRecognizerWithDirection:rootView direction:UISwipeGestureRecognizerDirectionUp];
     [self addSwipeGestureRecognizerWithDirection:rootView direction:UISwipeGestureRecognizerDirectionDown];
+}
+
+RCT_EXPORT_METHOD(connectLongPress) {
+    self.recognizeSimultaneously = NO;
+    UIView *rootView = [self getRootViewController].view;
     
     [self addLongPressGestureRecognizer:rootView];
+}
+
+RCT_EXPORT_METHOD(disconnect) {
+    [self disconnectTap];
+    [self disconnectSwipe];
+    [self disconnectLongPress];
+}
+
+RCT_EXPORT_METHOD(disconnectTap) {
+    if (!tapRecognizers) return;
+
+    UIView *view = [self getRootViewController].view;
+    
+    for (UIGestureRecognizer *recognizer in tapRecognizers)
+    {
+        recognizer.enabled = NO;
+        [view removeGestureRecognizer:recognizer];
+    }
+}
+
+RCT_EXPORT_METHOD(disconnectSwipe) {
+    if (!swipeRecognizers) return;
+
+    UIView *view = [self getRootViewController].view;
+    
+    for (UIGestureRecognizer *recognizer in swipeRecognizers)
+    {
+        recognizer.enabled = NO;
+        [view removeGestureRecognizer:recognizer];
+    }
+}
+
+RCT_EXPORT_METHOD(disconnectLongPress) {
+    if (!longPressRecognizers) return;
+
+    UIView *view = [self getRootViewController].view;
+    
+    for (UIGestureRecognizer *recognizer in longPressRecognizers)
+    {
+        recognizer.enabled = NO;
+        [view removeGestureRecognizer:recognizer];
+    }
 }
 
 RCT_EXPORT_METHOD(enablePanGesture) {
@@ -65,24 +127,27 @@ RCT_EXPORT_METHOD(disableRecognizeSimultaneously) {
     return rootVC;
 }
 
-- (void)addTapGestureRecognizerWithType:(UIView *)view pressType:(UIPressType)pressType selector:(SEL)selector {
+- (UITapGestureRecognizer *)addTapGestureRecognizerWithType:(UIView *)view pressType:(UIPressType)pressType selector:(SEL)selector {
     UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:selector];
     tapGestureRecognizer.allowedPressTypes = @[[NSNumber numberWithInteger:pressType]];
     [view addGestureRecognizer:tapGestureRecognizer];
     tapGestureRecognizer.delegate = self;
+    return tapGestureRecognizer;
 }
 
-- (void)addSwipeGestureRecognizerWithDirection:(UIView *)view direction:(UISwipeGestureRecognizerDirection)direction {
+- (UISwipeGestureRecognizer *)addSwipeGestureRecognizerWithDirection:(UIView *)view direction:(UISwipeGestureRecognizerDirection)direction {
     UISwipeGestureRecognizer *swipeGestureRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(respondToSwipeGesture:)];
     swipeGestureRecognizer.direction = direction;
     [view addGestureRecognizer:swipeGestureRecognizer];
     swipeGestureRecognizer.delegate = self;
+    return swipeGestureRecognizer;
 }
 
-- (void)addLongPressGestureRecognizer:(UIView *)view {
+- (UILongPressGestureRecognizer * )addLongPressGestureRecognizer:(UIView *)view {
     UILongPressGestureRecognizer *longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(respondToLongPressGesture:)];
     [view addGestureRecognizer:longPressGestureRecognizer];
     longPressGestureRecognizer.delegate = self;
+    return longPressGestureRecognizer;
 }
 
 - (void)respondToPlayPauseButton {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.5",
   "description": "TvOS remote controller module for react native.",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I ran into problems with `connect` breaking the `BackHandler` even though I wasn't using the `TAP` event. This could be solved by not registering the `UITapGestureRecognizer` or by removing it when navigating away.

This PR adds both solutions. It adds connect functions for each type of gesture recognizer and disconnect functions for each.

It also adds a TypeScript definition.