### PR TITLE
accessing RootViewControllers from main thread

### DIFF
--- a/ios/RNtvoscontroller/RNtvoscontroller.m
+++ b/ios/RNtvoscontroller/RNtvoscontroller.m
@@ -19,9 +19,11 @@ NSMutableArray *longPressRecognizers;
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(connect) {
-    [self connectTap];
-    [self connectSwipe];
-    [self connectLongPress];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self connectTap];
+        [self connectSwipe];
+        [self connectLongPress];
+    });
 }
 
 RCT_EXPORT_METHOD(connectTap) {


### PR DESCRIPTION
If you turn on the Main Thread Checker in XCode you will see the following when using react-native-tvos-controller:

![Screenshot 2019-03-14 08 59 18](https://user-images.githubusercontent.com/757580/54364005-766ab000-4642-11e9-969c-33292084480b.png)

```-[UIApplication delegate] must be used from the main thread only```

Also from [this Apple documentation](https://developer.apple.com/documentation/uikit)
_Use UIKit classes only from your app’s main thread or main dispatch queue, unless otherwise indicated. This restriction particularly applies to classes derived from UIResponder or that involve manipulating your app’s user interface in any way._

My app would run on AppleTV for a few minutes and then just eject to the home screen.  When I remove react-native-tvos-controller that issue is resolved.  I believe this fix for talking to the ViewController  from the main queue will resolve this.